### PR TITLE
feat: update policy and kms key for ses

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -43,20 +43,6 @@ resource "aws_kms_key" "inbound" {
             "kms:GrantIsForAWSResource" = true
           }
         }
-      },
-      {
-        Sid       = "AllowSQSUse", # For SQS encryption if needed
-        Effect    = "Allow",
-        Principal = "*",
-        Action    = ["kms:Encrypt", "kms:Decrypt", "kms:ReEncrypt*", "kms:GenerateDataKey*", "kms:DescribeKey", "kms:CreateGrant"],
-        Resource  = "*",
-        Condition = {
-          StringEquals = {
-            "kms:CallerAccount" = local.account_id,
-            "kms:ViaService"    = "sqs.${local.region}.amazonaws.com"
-          },
-          Bool = { "kms:GrantIsForAWSResource" = true }
-        }
       }
     ]
   })


### PR DESCRIPTION
This is a issue when inherent KMS policies don’t align with SES’s test PUT behavior. A more robust solution than encryption-flipping is to:
- Specify kms_key_arn in the SES S3 action.